### PR TITLE
Prepare for deployment on Heroku

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,9 +15,7 @@
     "react-dom": "^16.13.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "socket.io-client": "^2.3.0"
-  },
-  "devDependencies": {
+    "socket.io-client": "^2.3.0",
     "@babel/core": "^7.10.5",
     "@babel/preset-env": "^7.10.4",
     "@babel/preset-react": "^7.10.4",

--- a/client/src/components/buttons/LogOut.jsx
+++ b/client/src/components/buttons/LogOut.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import logoutIcon from '../../media/nav-icons/logout.svg';
 
 const LogOut = () => (
-    <a href='http://localhost:5000/auth/logout'>
+    <a href='/auth/logout'>
         <span className='hidden md:inline'>Logout</span>
         <img className='inline md:hidden w-8' src={logoutIcon} />
     </a>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "eruditio",
+  "version": "1.0.0",
+  "description": "A tutoring platform created as a final project for [Salt](https://salt.study/).",
+  "main": "server/server.js",
+  "scripts": {
+    "start": "cd server && npm i && node server.js",
+    "heroku-postbuild": "cd client && npm i && npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/arturjzapater/eruditio.git"
+  },
+  "keywords": [],
+  "contributors": [{
+    "name": "Artur J Zapater"
+  }, {
+    "name": "Kristina Mutalapove"
+  }, {
+    "name": "Pontus Sandberg"
+  }],
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/arturjzapater/eruditio/issues"
+  },
+  "homepage": "https://github.com/arturjzapater/eruditio#readme"
+}


### PR DESCRIPTION
This PR adds three changes to the code:
- New (package.json) at the root folder with Heroku actions to perform the build and start the server
- Move webpack from devDependencies to dependencies in the client, otherwise Heroku doesn't seem to find it
- Fix logout link so it doesn't redirect the user to localhost anymore