### PR TITLE
fixed typing issues in UserForm

### DIFF
--- a/client/src/components/UserForm.tsx
+++ b/client/src/components/UserForm.tsx
@@ -38,7 +38,7 @@ const UserForm: React.FC<UserFormProps> = ({ onSubmit, hasProfile }) => {
     const [ state, setState ] = useState(initState);
     const [ error, setError ] = useState('');
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>): void => {
         const { name, value } = event.target;
         setState({
             ...state,

--- a/client/src/lib/interfaces.ts
+++ b/client/src/lib/interfaces.ts
@@ -57,7 +57,7 @@ export interface FormHeaderProps {
 export interface InputProps {
     label: string,
     name: string,
-    onChange: (event: React.FormEvent) => void
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
 
 export interface TutorCardProps {
@@ -121,8 +121,8 @@ export interface DropDownProps {
     name: string,
     options: Array<{value: string, name: string}>,
     init: string,
-    onChange: (event: React.ChangeEvent) => void,
-    multiple: boolean,
+    onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void,
+    multiple?: boolean,
 }
 
 export interface HeaderProps {


### PR DESCRIPTION
I have done a quick check of the problems in UserForm, and there were a few irreconcilable typing issues. I have changed the types according to what TypeScript expected. Here's what I've done:

- The function `handleChange` in UserForm now accepts an event of the type `React.ChangeEvent<HTMLInputElement | HTMLSelectElement>`. I chose those because that's the specific elements from which the event comes and other more generic event types don't have the properties `name` and `value`.

- I have updated the interfaces `DropDownProps` and `InputProps` to match the event that `handleChange` expects. Again, a more generic event wouldn't be reconciled with the type that `handleChange` needs.

- I have made the prop `multiple` optional in `DropDownProps`, since it has a default value and we don't always pass it.